### PR TITLE
Fix bug where transparency of 0 is ignored

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,16 +118,8 @@ class BarcodeMask extends React.Component {
   };
 
   _applyMaskFrameTransparency = () => {
-    let transparency = 0.6;
-    if (
-      this.props.transparency &&
-      Number(this.props.transparency) &&
-      (this.props.transparency >= 0 || this.props.transparency <= 1)
-    ) {
-      transparency = this.props.transparency;
-    }
-    return { backgroundColor: 'rgba(0,0,0,' + transparency + ')' };
-  };
+    return { backgroundColor: `rgba(0,0,0,${this.props.transparency})` };
+  }
 
   _renderEdge = (edgePosition) => {
     const defaultStyle = {


### PR DESCRIPTION
Since `0` is falsey in javascript, we were ignoring `this.props.transparency` when it was set to `0`. Also remove the redundant default value (already defined by `defaultProps`)