### PR TITLE
Pass through nativeEvent as is to callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,7 +182,7 @@ class BarcodeMask extends React.Component {
         finderLayout: layout,
     })
     if (onLayoutMeasured) {
-        onLayoutMeasured(nativeEvent);
+        onLayoutMeasured({ nativeEvent });
     }
   }
 


### PR DESCRIPTION
nativeEvent is not passed the same way as it's received. Also it breaks typescript definition.