### PR TITLE
(tiny): Fix edge overlay issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const styles = StyleSheet.create({
   finder: {
     alignItems: 'center',
     justifyContent: 'center',
+    zIndex: 1,
   },
   topLeftEdge: {
     position: 'absolute',


### PR DESCRIPTION
Fixes edge overlay issue mentioned in [#49](https://github.com/shahnawaz/react-native-barcode-mask/issues/49) by simply bringing the finder container up in the vertical axis.

**Before**
![Image from iOS (3)](https://user-images.githubusercontent.com/30811027/151675656-8a059eb6-867a-468a-88d9-bdc70a34ea03.jpg)

**After**
![Image from iOS (2)](https://user-images.githubusercontent.com/30811027/151675660-4ba93e59-fe0d-4011-bf03-b4411d2d6d70.jpg)

